### PR TITLE
Remove `apt-get upgrade` and condense installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,28 @@
 FROM postgres:9.6.5
 MAINTAINER Phil Chin <ekkus93@gmail.com>
 
-RUN apt-get update && apt-get upgrade -y 
-RUN apt-get install wget screen -y
-RUN apt-get install lsb-core -y
+RUN apt-get update \
+ && apt-get install -y \
+    # general system dependencies
+    wget screen lsb-core \
+    # editors for dev purposes
+    emacs vim nano \
+    # python and pip system dependencies
+    gdal-bin binutils libproj-dev python3-pip \
+    build-essential libssl-dev libffi-dev python3-dev \
+    python3-lxml python3-matplotlib libpq-dev python-dev \
+    python3-gdal libxml2-dev libxslt-dev \
+    # postgresql extensions
+    postgresql-9.6-postgis-2.4 \
+ && rm -rf /var/lib/apt/lists
 
-#emacs
-# update again otherwise emacs might fail to install
-RUN apt-get update && apt-get upgrade -y 
-RUN apt-get install emacs -y --fix-missing
-
-# python
-RUN apt-get remove --auto-remove gdal-bin -y
-RUN apt-get install binutils libproj-dev gdal-bin -y
-
-RUN apt-get install -y python3-pip
-RUN pip3 install --upgrade setuptools
-RUN apt-get install build-essential libssl-dev libffi-dev python3-dev
-RUN pip3 install cffi
-#RUN pip3 install Cython
-RUN pip3 install cryptography==2.1.1
-RUN pip3 install virtualenv
-RUN apt-get install python3-lxml -y 
-
-RUN apt-get install python3-matplotlib -y
-
-# postgis
-RUN apt-get install postgresql-9.6-postgis-2.4 -y
-
-# gdal
-#RUN add-apt-repository ppa:ubuntugis/ubuntugis-unstable
-RUN apt-get update
-RUN apt-get install libpq-dev python-dev -y
-RUN apt-get install gdal-bin python3-gdal -y
-
-# xml stuff
-RUN apt-get -y install libxml2-dev libxslt-dev
-
-# text editors
-RUN apt-get install vim nano -y
+# upgrade setuptools first, see:
+#   https://github.com/ansible/ansible/issues/31741#issuecomment-336889622
+RUN pip3 install --upgrade setuptools \
+ && pip3 install cffi cryptography==2.1.1 virtualenv
 
 # home dir
-RUN mkdir -p /home/postgres/scripts
-RUN mkdir -p /home/postgres/work
+RUN mkdir -p /home/postgres/scripts /home/postgres/work
 RUN usermod -d /home/postgres postgres
 
 # set bash shell


### PR DESCRIPTION
I just spent the better part of two hours debugging this:

```
» psql -h 0.0.0.0 -p 7432
psql: server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
```

when trying to connect to the running container.

I was not able to reproduce the error when using the `postgres:9.6.5`
image directly, thus something in the build process must be severing the
connection when I try to connect.

The only explanation I can muster is that the `apt-get upgrade`
accidentally upgrades PostgreSQL into a silently-incompatible place.

Generally speaking, doing an `apt-get upgrade` in a docker build is an
anti-pattern, as you should just use a more recent upstream image
instead. So I removed it. After that, everything seems to work.

Also, I merged the `apt-get install` commands into a single place, for
purposes of reducing the overall size and layer count of the built
image.